### PR TITLE
Product improvements

### DIFF
--- a/stubs/resources/views/shop/product/default/_price.antlers.html
+++ b/stubs/resources/views/shop/product/default/_price.antlers.html
@@ -18,7 +18,7 @@
             {{ /if }}
 
             {{ if {gaia:product:configurable} }}
-                <span class="block mt-2 text-3xl">From {{ gaia:currency :price="min_display_price" }}</span>
+                <span class="block mt-2 text-3xl">{{ unless is_uniform_price }}From{{ /unless }} {{ gaia:currency :price="min_display_price" }}</span>
             {{ /if }}
         {{ /gaia:product:price }}
     </span>
@@ -37,11 +37,11 @@
                 </div>
             </template>
 
-            <template x-if="(! $store.product.priceTable.isDiscounted) && ($store.product.areAllOptionsSelected)">
+            <template x-if="(! $store.product.priceTable.isDiscounted) && $store.product.currentProduct != undefined">
                 <span class="block mt-2 text-3xl" x-text="$store.product.priceTable.formattedMinPrice"></span>
             </template>
 
-            <span x-show="! $store.product.areAllOptionsSelected" class="block mt-2 text-3xl">From <span x-text="$store.product.priceTable.formattedMinPrice"></span>
+            <span x-show="$store.product.currentProduct == undefined" class="block mt-2 text-3xl">From <span x-text="$store.product.priceTable.formattedMinPrice"></span>
         </span>
     {{ /if }}
 </div>

--- a/stubs/resources/views/shop/product/default/index.antlers.html
+++ b/stubs/resources/views/shop/product/default/index.antlers.html
@@ -194,6 +194,7 @@
                         discountPercentage: discountPercentage(),
                         discountAmount: discountAmount(),
                         formattedDiscountAmount: formatPrice(discountAmount()),
+                        isUniformPrice: minPrice() === maxPrice(),
                     }
                 },
                 updateCurrentVariants() {

--- a/stubs/resources/views/shop/product/default/index.antlers.html
+++ b/stubs/resources/views/shop/product/default/index.antlers.html
@@ -284,8 +284,7 @@
                     }
 
                     if (this.isProductQtyMoreThanAvailable) {
-                        // TODO: fix this, alerts no longer exist
-                        gaia.alert({
+                        gaia.toast({
                             title: 'Not enough stock',
                             text: `Sorry, we don't have enough stock for that quantity. Please select something less than ${this.currentProduct.inventory_quantity + 1}`,
                             type: 'error'

--- a/stubs/resources/views/shop/product/default/index.antlers.html
+++ b/stubs/resources/views/shop/product/default/index.antlers.html
@@ -61,8 +61,9 @@
                     this.updateProductData();
                 },
                 findVariantBySelectedOptions(options) {
-                    if (!options || Object.keys(options).length < 3) return undefined;
-                    return this.variants.find(variant => {
+                    if (! options) return undefined;
+
+                    return this.variants.filter(variant => {
                         return Object.keys(options).every(key => {
                             const optionNumber = parseInt(key);
                             const optionKey = `option${optionNumber}`;
@@ -80,12 +81,26 @@
                 updateCurrentProduct() {
                     let variant;
 
-                    variant = this.variants.length === 1 ? this.variants[0] : this.findVariantBySelectedOptions(this.selectedOptions);
+                    // If there is only one variant initially, we know that this is 
+                    // a single, unconfigurable product. The shopify addon adds a 
+                    // single variant, even if there are no product options.
+                    if (this.variants.length === 1) {
+                        variant = this.variants[0];
+                    } else {
+                        variant = this.findVariantBySelectedOptions(this.selectedOptions);
+                    }
 
-                    if (!variant) {
+                    // If there is more than one variant found we know 
+                    // not all selected options have been selected yet
+                    if (! variant || variant.length !== 1) {
                         this.currentProduct = undefined;
+
                         return;
                     }
+
+                    // If there is only one variant found we know all selected options 
+                    // have been selected so grab the first one of the array.
+                    variant = variant[0];
 
                     this.currentProduct =  {
                         ...variant,


### PR DESCRIPTION
- No longer need all product options selected to buy the product.
- Fixes an issue where the from label was displaying, even if the price was uniform. 
- Removed `gaia.alert` with `gaia.toast`.